### PR TITLE
feat: decode CNetworkUtlVectorBase<uint8> fields as Uint8Array

### DIFF
--- a/scripts/generate-entity-types.ts
+++ b/scripts/generate-entity-types.ts
@@ -43,7 +43,8 @@ const DECODER_ID_TO_TS: Record<number, string> = {
 	18: 'number', // D_BASE
 	19: 'number', // D_AMMO
 	20: '[number, number, number]', // D_QANGLE_PRES
-	21: 'number' // D_GAME_MODE_RULES
+	21: 'number', // D_GAME_MODE_RULES
+	23: 'Uint8Array' // D_BYTE_VECTOR (CNetworkUtlVectorBase<uint8>)
 };
 
 function decoderToTsType(decoder: Decoder): string {

--- a/src/generated/entityTypes.ts
+++ b/src/generated/entityTypes.ts
@@ -1,5 +1,5 @@
 // AUTO-GENERATED - DO NOT EDIT
-// Generated from demo: snapshot on 2026-05-19
+// Generated from demo: snapshot on 2026-05-22
 
 /** Prefixes all keys of T with "P." */
 type Prefixed<P extends string, T> = {
@@ -43,7 +43,7 @@ interface _CBodyComponentBaseAnimGraph {
 	readonly "m_nServerGraphInstanceIteration"?: number;
 	readonly "m_nServerSerializationContextIteration"?: number;
 	readonly "m_primaryGraphId"?: number;
-	readonly "m_SerializePoseRecipeAG2Dynamic"?: number;
+	readonly "m_SerializePoseRecipeAG2Dynamic"?: Uint8Array;
 	readonly "m_topology"?: unknown;
 	readonly "m_vecExternalClipIds"?: number;
 	readonly "m_vecExternalGraphIds"?: number;
@@ -311,7 +311,7 @@ interface _CCSPlayer_WeaponServices {
 	readonly "m_hLastWeapon"?: number;
 	readonly "m_hMyWeapons"?: number;
 	readonly "m_iAmmo"?: number;
-	readonly "m_networkAnimTiming"?: number;
+	readonly "m_networkAnimTiming"?: Uint8Array;
 }
 
 interface _CCSPlayerController_ActionTrackingServices {
@@ -1479,7 +1479,7 @@ interface _CCSPlayer_WeaponServicesOwn {
 	readonly "m_hLastWeapon"?: number;
 	readonly "m_hMyWeapons"?: number;
 	readonly "m_iAmmo"?: number;
-	readonly "m_networkAnimTiming"?: number;
+	readonly "m_networkAnimTiming"?: Uint8Array;
 }
 
 interface _CCSPlayerControllerOwn {
@@ -3200,7 +3200,7 @@ interface _CSmokeGrenadeProjectileOwn {
 	readonly "m_vecZ"?: number;
 	readonly "m_vInitialPosition"?: [number, number, number];
 	readonly "m_vInitialVelocity"?: [number, number, number];
-	readonly "m_VoxelFrameData"?: number;
+	readonly "m_VoxelFrameData"?: Uint8Array;
 	readonly "m_vSmokeColor"?: [number, number, number];
 	readonly "m_vSmokeDetonationPos"?: [number, number, number];
 }

--- a/src/generated/serializerSnapshot.json
+++ b/src/generated/serializerSnapshot.json
@@ -37,7 +37,7 @@
       "m_nServerGraphInstanceIteration": "number",
       "m_nServerSerializationContextIteration": "number",
       "m_primaryGraphId": "number",
-      "m_SerializePoseRecipeAG2Dynamic": "number",
+      "m_SerializePoseRecipeAG2Dynamic": "Uint8Array",
       "m_topology": "unknown",
       "m_vecExternalClipIds": "number",
       "m_vecExternalGraphIds": "number",
@@ -343,7 +343,7 @@
       "m_hLastWeapon": "number",
       "m_hMyWeapons": "number",
       "m_iAmmo": "number",
-      "m_networkAnimTiming": "number"
+      "m_networkAnimTiming": "Uint8Array"
     },
     "CCSPlayer_ItemServices": {
       "m_bHasDefuser": "boolean",
@@ -1747,7 +1747,7 @@
         "m_hLastWeapon": "number",
         "m_hMyWeapons": "number",
         "m_iAmmo": "number",
-        "m_networkAnimTiming": "number"
+        "m_networkAnimTiming": "Uint8Array"
       }
     },
     "CCSPlayer_ItemServices": {
@@ -4857,7 +4857,7 @@
         "m_vecZ": "number",
         "m_vInitialPosition": "[number, number, number]",
         "m_vInitialVelocity": "[number, number, number]",
-        "m_VoxelFrameData": "number",
+        "m_VoxelFrameData": "Uint8Array",
         "m_vSmokeColor": "[number, number, number]",
         "m_vSmokeDetonationPos": "[number, number, number]"
       }

--- a/src/parser/entities/constructorFields.ts
+++ b/src/parser/entities/constructorFields.ts
@@ -134,6 +134,10 @@ const D_AMMO = 19;
 const D_QANGLE_PRES = 20;
 const D_GAME_MODE_RULES = 21;
 const D_BINARY_BLOCK = 22;
+// Marker only — never used to decode a wire value. Stored in propIdToDecoder so the
+// type generator surfaces CNetworkUtlVectorBase<uint8> fields as Uint8Array. The bytes
+// themselves are decoded element-by-element with the Unsigned decoder.
+const D_BYTE_VECTOR = 23;
 
 export type QuantalizedFloatDecoder = { type: typeof D_QUANTALIZED_FLOAT; decoder: number };
 export type Decoder = number | QuantalizedFloatDecoder;
@@ -161,7 +165,8 @@ export const Decoders = {
 	AmmoDecoder: D_AMMO,
 	QanglePresDecoder: D_QANGLE_PRES,
 	GameModeRulesDecoder: D_GAME_MODE_RULES,
-	BinaryBlockDecoder: D_BINARY_BLOCK
+	BinaryBlockDecoder: D_BINARY_BLOCK,
+	ByteVectorDecoder: D_BYTE_VECTOR
 };
 
 const decoderMap: { [K in string]?: Decoder } = {
@@ -254,6 +259,9 @@ type ArrayField = {
 type VectorField = {
 	field_enum: Field;
 	decoder: Decoder;
+	// True for CNetworkUtlVectorBase<uint8> / CUtlVector<uint8>: a vector of raw bytes.
+	// Element field-paths are assembled into a Uint8Array instead of overwriting a scalar.
+	isByteVector: boolean;
 };
 
 type SerializerField = {
@@ -756,7 +764,14 @@ export const constructorFieldHelper = {
 							const result = `${serializerName}.${value.name}`;
 
 							map[currentEntityId.id] = result;
-							if (decoderMap) decoderMap[currentEntityId.id] = value.decoder;
+							if (decoderMap) {
+								// Byte vectors are assembled into a Uint8Array at decode time; record the
+								// marker decoder so generated types reflect that (the per-element decode
+								// still uses value.decoder).
+								decoderMap[currentEntityId.id] = (field.value as VectorField).isByteVector
+									? Decoders.ByteVectorDecoder
+									: value.decoder;
+							}
 							value.prop_id = currentEntityId.id;
 							currentEntityId.id++;
 							break;
@@ -799,9 +814,13 @@ export const constructorFieldHelper = {
 				length: field.fieldType.count ?? 0
 			});
 		} else if (field.category === FieldCategory.Vector) {
+			// A vector whose element is a raw byte (CNetworkUtlVectorBase<uint8> et al.) is
+			// surfaced as a Uint8Array rather than a single overwritten scalar.
+			const isByteVector = !field.serializer_name && field.fieldType.genericType?.baseType === 'uint8';
 			elementField = new Field(FieldTypeEnum.Vector, {
 				field_enum: elementField,
-				decoder: Decoders.UnsignedDecoder
+				decoder: Decoders.UnsignedDecoder,
+				isByteVector
 			});
 		}
 

--- a/src/parser/entities/entityParser.ts
+++ b/src/parser/entities/entityParser.ts
@@ -39,13 +39,16 @@ const getEntityType = (name: string) => {
 	return EntityTypeEnum.Normal;
 };
 
-// Reusable result object to avoid allocation per field
-const _fieldResult = { decoder: 0 as any, propId: 0, hasInfo: false };
+// Reusable result object to avoid allocation per field.
+// byteVectorOp: 0 = none, 1 = byte-vector length read, 2 = byte-vector element read.
+const _fieldResult = { decoder: 0 as any, propId: 0, hasInfo: false, byteVectorOp: 0, elementIndex: 0 };
 
 // Combined findField + getPropInfo + getDecoderFromField in one pass
 const findFieldAndDecode = (fp: FieldPath, ser: SerializerN) => {
 	const f = ser.fields[fp.path[0]];
 	if (!f) throw 'Noo field';
+
+	_fieldResult.byteVectorOp = 0;
 
 	// Fast path: depth-0 Value field (most common case)
 	if (fp.last === 0 && f.type === FieldTypeEnum.Value) {
@@ -56,9 +59,12 @@ const findFieldAndDecode = (fp: FieldPath, ser: SerializerN) => {
 		return _fieldResult;
 	}
 
-	// Traverse to leaf field
+	// Traverse to leaf field, keeping the immediate parent so we can recognise
+	// elements of a byte vector (parent is a Vector, leaf is its inner Value).
 	let field = f;
+	let parent: typeof f | null = null;
 	for (let depth = 1; depth <= fp.last; depth++) {
+		parent = field;
 		field = getInnerExt(field!, fp.path[depth]!);
 	}
 
@@ -69,6 +75,11 @@ const findFieldAndDecode = (fp: FieldPath, ser: SerializerN) => {
 		_fieldResult.decoder = v.decoder;
 		_fieldResult.propId = v.prop_id;
 		_fieldResult.hasInfo = true;
+		// A Value reached through a byte Vector is one byte at fp.path[fp.last].
+		if (parent !== null && parent.type === FieldTypeEnum.Vector && (parent.value as any).isByteVector) {
+			_fieldResult.byteVectorOp = 2;
+			_fieldResult.elementIndex = fp.path[fp.last]!;
+		}
 		return _fieldResult;
 	}
 
@@ -79,6 +90,8 @@ const findFieldAndDecode = (fp: FieldPath, ser: SerializerN) => {
 			const v = inner.value as any;
 			_fieldResult.propId = v.prop_id;
 			_fieldResult.hasInfo = true;
+			// Leaf is the vector itself: this read is the element count.
+			if ((field.value as any).isByteVector) _fieldResult.byteVectorOp = 1;
 		} else {
 			_fieldResult.hasInfo = false;
 		}
@@ -154,7 +167,34 @@ export class EntityParser {
 			if (info.hasInfo) {
 				if (entProps) {
 					const name = directPropIdToName![info.propId];
-					if (name !== undefined) entProps[name] = result;
+					if (name !== undefined) {
+						if (info.byteVectorOp === 0) {
+							entProps[name] = result;
+						} else if (info.byteVectorOp === 1) {
+							// Length read: size the backing Uint8Array, preserving any bytes
+							// already decoded (delta updates re-send the count then a subset).
+							const count = result as number;
+							const existing = entProps[name];
+							if (!(existing instanceof Uint8Array) || existing.length !== count) {
+								const arr = new Uint8Array(count);
+								if (existing instanceof Uint8Array)
+									arr.set(existing.subarray(0, Math.min(existing.length, count)));
+								entProps[name] = arr;
+							}
+						} else {
+							// Element read: write one byte, growing the array if it arrived early.
+							let arr = entProps[name] as Uint8Array | undefined;
+							const idx = info.elementIndex;
+							if (!(arr instanceof Uint8Array) || idx >= arr.length) {
+								const len = arr instanceof Uint8Array ? Math.max(arr.length, idx + 1) : idx + 1;
+								const grown = new Uint8Array(len);
+								if (arr instanceof Uint8Array) grown.set(arr);
+								arr = grown;
+								entProps[name] = arr;
+							}
+							arr[idx] = result as number;
+						}
+					}
 				} else if (emitEntityUpdates && classPropIdToName[info.propId] !== undefined) {
 					this.enqueueEvent('entityupdated', { entityId, propId: info.propId, value: result });
 				}

--- a/src/parser/entities/entityParser.ts
+++ b/src/parser/entities/entityParser.ts
@@ -75,10 +75,20 @@ const findFieldAndDecode = (fp: FieldPath, ser: SerializerN) => {
 		_fieldResult.decoder = v.decoder;
 		_fieldResult.propId = v.prop_id;
 		_fieldResult.hasInfo = true;
-		// A Value reached through a byte Vector is one byte at fp.path[fp.last].
-		if (parent !== null && parent.type === FieldTypeEnum.Vector && (parent.value as any).isByteVector) {
-			_fieldResult.byteVectorOp = 2;
-			_fieldResult.elementIndex = fp.path[fp.last]!;
+		// A Value reached through a Vector or fixed Array is element
+		// fp.path[fp.last] of it. Byte vectors (op 2) assemble into a
+		// Uint8Array; any other element-addressed collection (op 4) assembles
+		// into a plain Array, so e.g. a fixed Vector[] like CInferno's
+		// m_firePositions keeps every element instead of each one overwriting
+		// the same property (which collapsed it to the last-written element).
+		if (parent !== null) {
+			if (parent.type === FieldTypeEnum.Vector) {
+				_fieldResult.byteVectorOp = (parent.value as any).isByteVector ? 2 : 4;
+				_fieldResult.elementIndex = fp.path[fp.last]!;
+			} else if (parent.type === FieldTypeEnum.Array) {
+				_fieldResult.byteVectorOp = 4;
+				_fieldResult.elementIndex = fp.path[fp.last]!;
+			}
 		}
 		return _fieldResult;
 	}
@@ -91,7 +101,8 @@ const findFieldAndDecode = (fp: FieldPath, ser: SerializerN) => {
 			_fieldResult.propId = v.prop_id;
 			_fieldResult.hasInfo = true;
 			// Leaf is the vector itself: this read is the element count.
-			if ((field.value as any).isByteVector) _fieldResult.byteVectorOp = 1;
+			// op 1 sizes a Uint8Array (byte vector), op 3 sizes a plain Array.
+			_fieldResult.byteVectorOp = (field.value as any).isByteVector ? 1 : 3;
 		} else {
 			_fieldResult.hasInfo = false;
 		}
@@ -181,7 +192,7 @@ export class EntityParser {
 									arr.set(existing.subarray(0, Math.min(existing.length, count)));
 								entProps[name] = arr;
 							}
-						} else {
+						} else if (info.byteVectorOp === 2) {
 							// Element read: write one byte, growing the array if it arrived early.
 							let arr = entProps[name] as Uint8Array | undefined;
 							const idx = info.elementIndex;
@@ -193,6 +204,30 @@ export class EntityParser {
 								entProps[name] = arr;
 							}
 							arr[idx] = result as number;
+						} else if (info.byteVectorOp === 3) {
+							// Generic (non-byte) vector length: size a plain Array, keeping
+							// already-decoded elements. Shrinking drops the tail (e.g. a
+							// CInferno's fires burning out); growing leaves holes the element
+							// reads below fill in.
+							const count = result as number;
+							const existing = entProps[name];
+							if (!Array.isArray(existing)) {
+								entProps[name] = new Array(count);
+							} else if (existing.length !== count) {
+								existing.length = count;
+							}
+						} else {
+							// Generic (non-byte) vector element (op 4): store at its index in a
+							// plain Array instead of overwriting one scalar. This is what keeps
+							// every element of a CNetworkUtlVectorBase<Vector> (m_firePositions,
+							// ...) rather than just the last one written.
+							let arr = entProps[name] as unknown[] | undefined;
+							const idx = info.elementIndex;
+							if (!Array.isArray(arr)) {
+								arr = [];
+								entProps[name] = arr;
+							}
+							arr[idx] = result;
 						}
 					}
 				} else if (emitEntityUpdates && classPropIdToName[info.propId] !== undefined) {


### PR DESCRIPTION
Vectors of primitives (e.g. CSmokeGrenadeProjectile.m_VoxelFrameData, typed CNetworkUtlVectorBase<uint8>) previously decoded to a single scalar: the field-path traversal generated one prop-id for the whole vector, so the length read and every per-element byte read overwrote the same property, leaving only the last byte.

Mark byte vectors at field construction (isByteVector) and, in the entity decode loop, distinguish the vector length read from element reads so the bytes are assembled into a Uint8Array indexed by element. A marker decoder (D_BYTE_VECTOR) is recorded in propIdToDecoder so the type generator surfaces these fields as Uint8Array.

Verified on a demo: m_VoxelFrameData now decodes to Uint8Array(3072) (1013 non-zero bytes) instead of the scalar 1, with m_bDidSmokeEffect, positions and other entities unaffected. Existing tests still pass.